### PR TITLE
Tide 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,15 @@ categories    = ["asynchronous", "authentication"]
 readme        = "README.md"
 
 [dependencies]
-http-types  = "2.4.0"
-tide        = "0.13.0"
-tracing     = "0.1.19"
-async-trait = "0.1.40"
-base64      = "0.12.3"
+http-types  = "2.7.0"
+tide        = "0.14.0"
+tracing     = "0.1.21"
+async-trait = "0.1.41"
+base64      = "0.13.0"
 
 [dev-dependencies]
-tide = "0.13.0"
-async-std = { version = "1.6.3", features = ["attributes"] }
+tide = "0.14.0"
+async-std = { version = "1.6.5", features = ["attributes"] }
 
 [[example]]
 name = "basic"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,15 @@ impl<User: Send + Sync + 'static, ImplScheme: Scheme<User>> Authentication<User,
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> Result<(), std::io::Error> { block_on(async {
+    /// #[derive(Clone)]
+    /// struct MyUserType {
+    ///     username: String
+    /// }
+    /// # fn main() -> Result<(), std::io::Error> { async_std::task::block_on(async {
     /// #
     /// use tide_http_auth::{ Authentication, BasicAuthScheme };
-    /// Authentication::new(BasicAuthScheme::default());
-    /// # Ok(()) }
+    /// Authentication::<MyUserType, BasicAuthScheme>::new(BasicAuthScheme::default());
+    /// # Ok(()) })}
     /// ```
     pub fn new(scheme: ImplScheme) -> Self {
         Self {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -11,6 +11,7 @@ use tide::Result;
 /// # fn main() -> Result<(), std::io::Error> { block_on(async {
 /// #
 /// use tide_http_auth::{ Storage, BasicAuthRequest, BasicAuthScheme };
+/// #[derive(Clone)]
 /// struct MyState;
 /// struct MyUserType {
 ///     username: String
@@ -20,10 +21,10 @@ use tide::Result;
 /// // note that we're implementing the concrete "BasicAuthRequest" type here.
 /// #[async_trait::async_trait]
 /// impl Storage<MyUserType, BasicAuthRequest> for MyState {
-///     async fn get_user(&self, request: BasicAuthRequest) -> tide::Result<MyUserType> {
+///     async fn get_user(&self, request: BasicAuthRequest) -> tide::Result<Option<MyUserType>> {
 ///       if request.username == "Basil" && request.password == "meow time now" {
 ///         // If the credential request succeeds, return your user type here.
-///         Ok(Some(MyUserType("Basil".to_string())))
+///         Ok(Some(MyUserType{username: "Basil".to_string()}))
 ///       } else {
 ///         Ok(None) // Nothing went wrong, but these credentials are invalid.
 ///         // you might also return Err here, to indicate a problem talking to the backing store.
@@ -34,7 +35,7 @@ use tide::Result;
 /// let mut app = tide::with_state(state);
 ///
 /// // BasicAuthScheme's ::Request associated type is BasicAuthRequest.
-/// app.middleware(tide_http_auth::Authentication::new(BasicAuthScheme::default()));
+/// app.with(tide_http_auth::Authentication::new(BasicAuthScheme::default()));
 ///
 /// # Ok(()) })}
 /// ```


### PR DESCRIPTION
This bumps version to tide-0.14, It was easiest to just build on top of #3, but theres no conflicts...
The only change that looked like it might have an impact was [removing parsing from Request::param](https://github.com/http-rs/tide/pull/709/commits/a125628bee0107aa54bb1ddf5350eff3d5407a64), but all seemed to be OK from what i could tell.

All the doc tests compile, and I ran through the example.