### PR TITLE
feat: do not use default tide features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1.41"
 base64      = "0.13.0"
 
 [dev-dependencies]
-tide = "0.16.0"
+tide = { version = "0.16.0", default-features = false }
 async-std = { version = "1.6.5", features = ["attributes"] }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,12 @@ readme        = "README.md"
 
 [dependencies]
 http-types  = "2.7.0"
-tide        = "0.16.0"
+tide        = { version = "0.16.0", default-features = false }
 tracing     = "0.1.21"
 async-trait = "0.1.41"
 base64      = "0.13.0"
 
 [dev-dependencies]
-tide = { version = "0.16.0", default-features = false }
 async-std = { version = "1.6.5", features = ["attributes"] }
 
 [[example]]


### PR DESCRIPTION
Remove use of Tide default crate features.. Without this I am forced to use Tide's default logger as well as a couple other features.